### PR TITLE
ci: standardize workflow with micromamba, fix rasterio PROJ conflict, verify ee-api fork

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Verify ee-api fork
         shell: micromamba-shell {0}
-        run: python -c "import ee; v=ee.__version__; print(f'ee-api: {v}'); assert v == '1.1.5rc0', f'Expected fork 1.1.5rc0, got {v}'"
+        run: |
+          python -c "import ee; v=ee.__version__; print('ee-api:', v); assert v == '1.1.5rc0', 'Expected fork 1.1.5rc0, got ' + v"
 
       - name: Install test deps
         shell: micromamba-shell {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,10 @@ jobs:
           environment-file: sepal_environment.yml
           cache-environment: true
 
+      - name: Verify ee-api fork
+        shell: micromamba-shell {0}
+        run: python -c "import ee; v=ee.__version__; print(f'ee-api: {v}'); assert v == '1.1.5rc0', f'Expected fork 1.1.5rc0, got {v}'"
+
       - name: Install test deps
         shell: micromamba-shell {0}
         run: pip install pytest nbmake ipykernel

--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - sepal-ui>=2.22.1,<3
   - pyproj
   - gdal
+  - rasterio<=1.4.3
   - pip
   - pip:
     - git+https://github.com/openforis/earthengine-api.git@v1.1.5rc0#egg=earthengine-api&subdirectory=python
-    - rasterio<=1.4.3

--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -5,10 +5,10 @@ channels:
 
 dependencies:
   - python=3.10
+  - sepal-ui>=2.22.1,<3
   - pyproj
   - gdal
   - pip
   - pip:
-    - sepal_ui==2.21.0
     - git+https://github.com/openforis/earthengine-api.git@v1.1.5rc0#egg=earthengine-api&subdirectory=python
     - rasterio<=1.4.3


### PR DESCRIPTION
## Summary

- Replaces legacy \`unit.yaml\` with standardized \`ci.yaml\` using \`mamba-org/setup-micromamba\`
- Moves \`rasterio\` and \`sepal-ui\` from pip to conda to fix PROJ/proj.db version mismatch (\`CRSError: DATABASE.LAYOUT.VERSION.MINOR = 2 whereas >= 3 expected\`)
- Adds a **Verify ee-api fork** step that asserts the openforis fork is installed instead of the conda-forge version

## Root cause of PROJ error
pip-installed \`rasterio\` bundles its own newer \`libproj\` which expects \`proj.db\` v3+, but conda's \`proj\` package ships v2. Fix: install both \`rasterio\` and \`sepal-ui\` via conda so all geospatial native libs are version-consistent.